### PR TITLE
Oracle implementation wraps mock implementation

### DIFF
--- a/dlc_test/Cargo.lock
+++ b/dlc_test/Cargo.lock
@@ -468,6 +468,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mocks"
+version = "0.1.0"
+source = "git+https://github.com/tvolk131/rust-dlc.git#5f66aefc5b5467115c1e572bcb2d7306c8f23f78"
+dependencies = [
+ "bitcoin",
+ "dlc",
+ "dlc-manager",
+ "dlc-messages",
+ "lightning",
+ "secp256k1-zkp",
+ "simple-wallet",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +612,7 @@ dependencies = [
  "dlc-sled-storage-provider",
  "hex",
  "lightning",
+ "mocks",
  "tokio",
 ]
 

--- a/dlc_test/Cargo.toml
+++ b/dlc_test/Cargo.toml
@@ -10,6 +10,7 @@ dlc = { git = "https://github.com/tvolk131/rust-dlc.git" }
 dlc-manager = { git = "https://github.com/tvolk131/rust-dlc.git" }
 dlc-messages = { git = "https://github.com/tvolk131/rust-dlc.git" }
 dlc-sled-storage-provider = { git = "https://github.com/tvolk131/rust-dlc.git" }
+mocks = { git = "https://github.com/tvolk131/rust-dlc.git" }
 hex = "0.4.3"
 lightning = "0.0.116"
 tokio = { version = "1.33.0", features = ["io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time"] }


### PR DESCRIPTION
Since the Rust DLC implementation already provides an in-memory implementation of an oracle, we're converting our `ResolvrOracle` struct to be a lightweight wrapper around this that's specifically used for bounties.