### PR TITLE
Fix Create Contract bounding box

### DIFF
--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -26,9 +26,11 @@ export default function ContractsPage() {
           <div className="flex items-center justify-between space-y-2">
             <h2 className="text-3xl font-bold tracking-tight">Contracts</h2>
             <div className="flex items-center space-x-2">
-              <Button>
-                <Link to="/create">Create Contract</Link>
-              </Button>
+              <Link to="/create">
+                <Button>
+                  Create Contract
+                </Button>
+              </Link>
             </div>
           </div>
           <Tabs defaultValue="overview" className="space-y-4">


### PR DESCRIPTION
Previously the bounds of the `<Link />` was only as big as the text inside of the button, not the entire button